### PR TITLE
first() and last() shouldn't modify self

### DIFF
--- a/lib/Web/Query.pm
+++ b/lib/Web/Query.pm
@@ -97,14 +97,12 @@ sub parent {
 
 sub first {
     my $self = shift;
-    $self->{trees} = +[$self->{trees}[0] || ()];
-    return $self;
+    return Web::Query->new_from_element([$self->{trees}[0] || ()], $self);
 }
 
 sub last {
     my $self = shift;
-    $self->{trees} = +[$self->{trees}[-1] || ()];
-    return $self;
+    return Web::Query->new_from_element([$self->{trees}[-1] || ()], $self);
 }
 
 sub find {


### PR DESCRIPTION
As jQuery docs says `.first() method constructs a new jQuery object from the first matching element`. In the current W::Q version first() and last() modifies $self and returns it. In the example below jQuery outputs "a" and "b", but W::Q outputs "a" and "a"

```
use Web::Query;
use strict;

my $xx = wq(q!<html>
<head>
<script src="http://code.jquery.com/jquery-1.6.min.js" type="text/javascript">
</script>
<script>
$(document).ready(function() {
    var xx = $(".xx");
    alert(xx.first().text());
    alert(xx.last().text());
})
</script>
</head>
<body>
<div class="xx">a</div>
<div class="xx">b</div>
</body>
</html>!)->find('.xx');

warn $xx->first->text;
warn $xx->last->text;
```
