### PR TITLE
choosing find() xpath root based on whether node has parent

### DIFF
--- a/lib/Web/Query.pm
+++ b/lib/Web/Query.pm
@@ -125,12 +125,14 @@ sub last {
 
 sub find {
     my ($self, $selector) = @_;
-
+    my $xpath_rootless = selector_to_xpath($selector);
+    
     my @new;
-    for my $tree (@{$self->{trees}}) {        
-        my $xpath = selector_to_xpath($selector, root => defined $tree->parent ? './' : '/');
-        push @new, $tree->findnodes($xpath);
+    for my $tree (@{$self->{trees}}) {
+        push @new, $tree if defined $tree->parent && $tree->matches($xpath_rootless);
+        push @new, $tree->findnodes(selector_to_xpath($selector, root => defined $tree->parent ? './' : '/'));
     }
+    
     return (ref $self || $self)->new_from_element(\@new, $self);
 }
 


### PR DESCRIPTION
we can get rid of $self->{root}, and find() will do the right thing.

So now we can write a detach() method like this:

```
sub detach {
    my ($self) = @_;
    $_->detach for @{$self->{trees}};
    #$self->{root} = '/'; # this line would be necessary in the current find() implementation
    $self;    
}
```

That being said, I think the correct behavior is to always use the $tree as the root for $tree->findnodes(), but include it in the search. I'm wondering if this is a limitation (or bug, or feature) of $tree->findnodes(), or xpath itself. :/

Btw, do you want PR for those (jquery compatible) methods I'm implementing in my subclass? 

So far I got those:
- append
- prepend
- after
- before
- insert_after
- insert_before
- detach
- add_class
- remove_class
- has_class

Thanks for attention.
