### PR TITLE
modified new_from_element() to ignore non-blessed items

### DIFF
--- a/lib/Web/Query.pm
+++ b/lib/Web/Query.pm
@@ -98,7 +98,7 @@ sub new_from_html {
 sub new_from_element {
     my $class = shift;
     my $trees = ref $_[0] eq 'ARRAY' ? $_[0] : +[$_[0]];
-    return bless { trees => $trees, before => $_[1] }, $class;
+    return bless { trees => +[ grep { blessed $_ } @$trees ], before => $_[1] }, $class;
 }
 
 sub end {

--- a/t/01_src.t
+++ b/t/01_src.t
@@ -41,6 +41,9 @@ if (eval "require URI; 1;") {
     };
 }
 
+my $wq = wq('file://' . Cwd::abs_path('t/data/html5_snippet.html'));
+is scalar(grep { not ref $_ } @{$wq->{trees}}), 0, 'new_from_element skips non blessed';
+
 done_testing;
 
 sub test {

--- a/t/data/html5_snippet.html
+++ b/t/data/html5_snippet.html
@@ -1,0 +1,3 @@
+<a>foo</a>
+<header>bar</header>
+<div>baz</div>


### PR DESCRIPTION
The change was needed because Web::Query methods assume $self->{trees} items are objects, but HTML::TreeBuilder sometimes (one case in t/data/html5_snippet.html) includes a bugus ' ' item in the list returned by $tree->guts().
