### PR TITLE
new_from_file() now calling guts() instead of elementify()

### DIFF
--- a/lib/Web/Query.pm
+++ b/lib/Web/Query.pm
@@ -81,7 +81,7 @@ sub new_from_file {
     my ($class, $fname) = @_;
     my $tree = $class->_build_tree;
     $tree->parse_file($fname);
-    my $self = $class->new_from_element([$tree->elementify]);
+    my $self = $class->new_from_element([$tree->guts]);
     $self->{need_delete}++;
     return $self;
 }

--- a/t/01_src.t
+++ b/t/01_src.t
@@ -10,6 +10,8 @@ subtest 'from file' => sub {
     test(wq('t/data/foo.html'));
 };
 
+is wq('t/data/html5_snippet.html')->size, 3, 'snippet from file';
+
 subtest 'from url' => sub {
     plan tests => 5;
     test(wq('file://' . Cwd::abs_path('t/data/foo.html')));


### PR DESCRIPTION
So the file can contain a document fragment (multiple root nodes) instead of a full document (single root).
Also, now all new_from_\* methods behave the same.
