### PR TITLE
fix syntax error of the sample code in SYNOPSIS

### DIFF
--- a/lib/Web/Query.pm
+++ b/lib/Web/Query.pm
@@ -471,7 +471,7 @@ Web::Query - Yet another scraping library like jQuery
           ->find('h2')
           ->each(sub {
                 my $i = shift;
-                printf("%d) %s\n", $i+1, $_->text
+                printf("%d %s\n", $i+1, $_->text);
           });
 
 =head1 DESCRIPTION


### PR DESCRIPTION
It seems to be just a typo.

But I think the sample code has a more important issue that the URL 'http://google.com/search?q=foobar` returns `301 Moved`

So I will send another pull request to fix it.
