### PR TITLE
modify sample codes in SYNPOSIS to work more stably

### DIFF
--- a/lib/Web/Query.pm
+++ b/lib/Web/Query.pm
@@ -467,12 +467,12 @@ Web::Query - Yet another scraping library like jQuery
 
     use Web::Query;
 
-    wq('http://google.com/search?q=foobar')
-          ->find('h2')
-          ->each(sub {
-                my $i = shift;
-                printf("%d) %s\n", $i+1, $_->text
-          });
+    wq('http://www.w3.org/TR/html401/')
+        ->find('div.head dt')
+        ->each(sub {
+            my $i = shift;
+            printf("%d %s\n", $i+1, $_->text);
+        });
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
This is another pull request against #25

The response or HTML structure of google.com often changes and is not always the same.
For example,
 'http://google.com/search?q=foobar`  returns `301 Moved`

``` html
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/search?q=foobar">here</A>.
```

and "http://www.google.com/search?q=foobar" returns `403 Forbidden`

``` sh
$ perl -MLWP::Simple -e 'getprint("http://www.google.com/search?q=foobar");'
403 Forbidden <URL:http://www.google.com/search?q=foobar>
```

(maybe Google denies some kind of user-agent, I don't know)

Even if Google accept the request, HTML strucutres of response will possibly be changed in the future.
The point is that nobody can assure google's response and HTML structures
This is a kind of hurdle for beginners.

So I propose to use more stable web pages. 
e.g. http://www.w3.org/TR/html401/

The new sample code works fine and the output is very simple like this:

```
1 This version:
2 Latest version of HTML 4.01:
3 Latest version of HTML 4:
4 Latest version of HTML:
5 Previous version of HTML 4.01:
6 Previous HTML 4 Recommendation:
7 Editors:
```
