### PR TITLE
destructor clobbering $@

### DIFF
--- a/lib/Web/Query.pm
+++ b/lib/Web/Query.pm
@@ -706,6 +706,7 @@ sub DESTROY {
     return unless $_[0]->{need_delete};
 
     # avoid memory leaks
+    local $@;
     eval { $_->delete } for @{$_[0]->{trees}};
 }
 

--- a/t/destroy.t
+++ b/t/destroy.t
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use lib 'lib';
+use Test::More;
+use Web::Query ();
+
+my $wq = Web::Query->new('<html><body></body></html>');
+local $@ = 'foo';
+$wq->DESTROY;
+is $@, 'foo', 'eval error string should not be clobbered';
+
+done_testing;


### PR DESCRIPTION
Patch to localize $@ in the destructor so it won't clobber outer $@ value.

I'm able to consistently reproduce the problem with this example:

```perl
#!/usr/bin/env perl

use strict;
use warnings;
use Data::Dumper;
use Web::Query;

$| = 1;

# $Data::Dumper::Useperl = 1;

my $success = eval {
  my $wq = Web::Query->new('<html><body></body></html>');
  my $rv = $wq->find('body');
  die "foo", Dumper($rv), "\n";

  1;
};
die "eval failed: $@" if !$success;

print "at end\n";
```

That dies with "eval failed:  at ./try line 19" for me. IOW, the 'foo' exception message is lost.

For some reason, using Dumper() there triggers it consistently for me. If I remove that, it doesn't.
So I wrote the test to call DESTROY() directly to reproduce the problem. I'm not sure if that's the best way to go about it or not.
